### PR TITLE
Update eip-7281.md (broken link)

### DIFF
--- a/EIPS/eip-7281.md
+++ b/EIPS/eip-7281.md
@@ -347,7 +347,7 @@ Note: In most of the above cases, a custom bridge integration also means integra
 
 ## Reference Implementation
 
-You can find a reference implementation and associated test cases [here](https://github.com/defi-wonderland/xTokens/blob/dev/solidity/contracts/XERC-20.sol).
+You can find a reference implementation and associated test cases [here](https://github.com/defi-wonderland/xERC20/blob/main/solidity/contracts/XERC20.sol).
 
 ## Security Considerations
 


### PR DESCRIPTION
fix: broken link

Appears that the reference implementation repository has been updated since the EIP was posted, leaving a link broken. This PR simply replaces the broken link with the up to date reference.